### PR TITLE
fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # path-filtering-custom-config
 
-Showcase how to run different continued config, with path-filtering.
+Showcase how to run different continued configs, with path-filtering.
 
 Please see the .circleci/config.yml file for details.
 


### PR DESCRIPTION
Here, we can see that the pipeline continued with the no-op workflow so no workflows followed up after the setup workflow:
https://app.circleci.com/pipelines/github/kelvintaywl-cci/path-filtering-custom-config/16